### PR TITLE
More package info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nordpool",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nordpool",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Nord Pool ELSPOT API client",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,5 +32,12 @@
     "mocha": "^3.5.3",
     "nock": "^9.6.1",
     "require-self": "^0.2.3"
+  },
+  "files": [
+    "lib/",
+    "config.js"
+  ],
+  "engines": {
+    "node": ">= 7.0.0"
   }
 }


### PR DESCRIPTION
- `files`: npm publish will now only include relevant files to use API.
- `engines`: will tell which version npm should install. Useful when later upgrading the main branch to no more support a specific node versions.